### PR TITLE
In-progress version of send_data: writing static 3D data using fms2_io

### DIFF
--- a/Makefile.mike
+++ b/Makefile.mike
@@ -1,6 +1,7 @@
 INTELHOME=/opt/intel/2019_up5/impi/2019.5.281/intel64
 GCCHOME=/opt/gcc/9.2.0
 YAMLHOME=/home/Miguel.Zuniga/diag_manager2/libyaml
+FIO2HOME=/home/Miguel.Zuniga/FMS/fms2_io
 
 ifeq ($(CC),gcc)
 	FTN=mpif90
@@ -19,12 +20,13 @@ else ifeq ($(CC),icc)
 endif
 
 
-INCLUDE=-I$(YAMLHOME)/include -I.  -I$(COMPHOME)/include
+INCLUDE= -I$(YAMLHOME)/include -I.  -I$(COMPHOME)/include -I$(FIO2HOME) #-I$(FIO2HOME)/include
 CFLAGS=-Wall -g
 
-LIB=-L$(YAMLHOME)/install/lib -L$(COMPHOME)/lib
+LIB=-L$(YAMLHOME)/install/lib -L$(COMPHOME)/lib -L$(FIO2HOME)
 
-l=-lyaml
+l=-lyaml 
+#$(FIO2HOME)/fms2_io.F90
 
 
 all: fms_diag_manager_test
@@ -32,9 +34,10 @@ all: fms_diag_manager_test
 fms_diag_manager_test: fms_diag_manager_test.x
 #	./$< 
 	
-fms_diag_manager_test.x: fms_diag_manager2.o fms_diag_register.o \
-	fms_diag_object.o fms_diag_table.F90 fms_diag_concur.o fms_diag_data.o \
-	fms_diag_parse.o fms_c_to_fortran.o fms_diag_send_data.o
+fms_diag_manager_test.x: fms_diag_util.o fms_diag_object.o fms_diag_register.o \
+	fms_diag_axis.o fms_diag_table.o fms_diag_concur.o \
+	fms_diag_data.o fms_diag_parse.o fms_c_to_fortran.o fms_diag_send_data.o \
+	fms_diag_write_data.o  fms_diag_averaging.o  fms_diag_manager2.o 
 #	$(MPFTN) $(INCLUDE) $(LIB) $(FFLAGS) $(l) $^ test/diag_manager2/diag_manager_test1.F90 -o $@
 #	mpirun -n 6 ./$@ : -n 7 ./$@
 #	mpirun -n 6 ./$@
@@ -55,27 +58,35 @@ parser_test: parser.x
 #	make clean
 	./$< diag_yaml
 	make clean
-omp_ave_test: diag_manager_averaging_test.x
+diag_ave_test: diag_manager_averaging_test.x
+#	make clean
+	./$< 
+	make clean
+	
+concur: concur.x
 #	make clean
 	./$< 
 	make clean
 	
 diag_table_test.x: fms_diag_data.o fms_c_to_fortran.o fms_diag_parse.o fms_diag_table.o  
 	$(FTN) $(INCLUDE) $(LIB) $(l) $(FFLAGS) $^  test/diag_table_test.F90 -o $@
-diag_manager_averaging_test.x: fms_diag_averaging.o fms_diag_omp_dummy.o
+diag_manager_averaging_test.x: fms_diag_averaging.o fms_diag_averaging_dummy.o
 	$(MPFTN) $(INCLUDE) $(LIB) $(l) $(FFLAGS) $^  test/diag_manager2/diag_manager_averaging_test.F90 -o $@
 	
 fms_diag_manager2.o:fms_diag_register.o fms_diag_object.o fms_diag_table.o \
-        fms_diag_data.o fms_diag_concur.o fms_diag_send_data.o
+        fms_diag_data.o fms_diag_concur.o fms_diag_send_data.o fms_diag_write_data.o 
 	$(MPFTN) $(INCLUDE) $(LIB) $(l) $(FFLAGS) $^ fms_diag_manager2.F90 -c 
+	
 fms_diag_register.o: fms_diag_object.o fms_diag_concur.o fms_diag_data.o 
 	$(MPFTN) $(INCLUDE) $(LIB) $(l) $(FFLAGS) $^ fms_diag_register.F90 -c
 fms_diag_table.o: fms_diag_parse.o fms_diag_data.o fms_c_to_fortran.o
 	$(FTN) $(INCLUDE) $(LIB) $(l) $(FFLAGS) $^ fms_diag_table.F90 -c 
 fms_diag_data.o: 
 	$(FTN) $(INCLUDE) $(LIB) $(l) $(FFLAGS) $^ fms_diag_data.F90 -c 
-fms_diag_object.o: fms_diag_table.o fms_diag_data.o
+fms_diag_object.o: fms_diag_table.o fms_diag_data.o fms_diag_axis.o
 	$(MPFTN) $(INCLUDE) $(LIB) $(l) $(FFLAGS) $^ fms_diag_object.F90 -c
+fms_diag_util.o: 
+	$(MPFTN) $(INCLUDE) $(LIB) $(l) $(FFLAGS) $^ fms_diag_util.F90 -c
 fms_diag_parse.o:
 	$(CC)  $(INCLUDE) $(LIB) $(l) $(CFLAGS) $^ fms_diag_parse.c -c 
 fms_diag_concur.o: fms_diag_data.o
@@ -84,12 +95,16 @@ fms_c_to_fortran.o:
 	$(MPFTN) $(INCLUDE) $(LIB) $(l) $(FFLAGS) $^ fms_c_to_fortran.F90 -c
 parser.x: fms_diag_parse.o
 	$(CC)  $(INCLUDE) $(LIB) $(l) -dynamic $(CFLAGS) $^ parser.c -o $@
-fms_diag_send_data.o:
+fms_diag_axis.o:
+	$(FTN) $(INCLUDE) $(LIB) $(l) $(FFLAGS) $^ fms_diag_axis.F90 -c 
+fms_diag_send_data.o: fms_diag_object.o fms_diag_averaging.o fms_diag_write_data.o
 	$(FTN) $(INCLUDE) $(LIB) $(l) $(FFLAGS) $^ fms_diag_send_data.F90 -c 
+fms_diag_write_data.o: fms_diag_object.o fms_diag_averaging.o fms_diag_data.o fms_diag_axis.o
+	$(FTN) $(INCLUDE) $(LIB) $(l) $(FFLAGS) $^ fms_diag_write_data.F90 -c 
 fms_diag_averaging.o:
 	$(FTN) $(INCLUDE) $(LIB) $(l) $(FFLAGS) $^ fms_diag_averaging.F90 -c 
-fms_diag_omp_dummy.o:
-	$(FTN) $(INCLUDE) $(LIB) $(l) $(FFLAGS) $^ fms_diag_omp_dummy.F90 -c 
+fms_diag_averaging_dummy.o:
+	$(FTN) $(INCLUDE) $(LIB) $(l) $(FFLAGS) $^ fms_diag_averaging_dummy.F90 -c 
 concur.x: fms_diag_concur.o fms_diag_data.o
 	$(MPFTN) $(FFLAGS) $^ test/concur/fms_diag_concur_test.F90 -o $@
 	mpirun -n 6 ./$@ : -n 7 ./$@

--- a/fms_diag_averaging.F90
+++ b/fms_diag_averaging.F90
@@ -9,7 +9,7 @@
 !! TODO 3) Determine loggin error policy (related to array allocation if any)
 !! TODO 4) Delete all experimental subroutines
 
-module fms_diag_averaging
+module fms_diag_averaging_mod
     use omp_lib
     implicit none
     private get_average_1D, get_average_2D, get_average_3D, get_average_4D, &
@@ -248,5 +248,5 @@ end function num_offloading_threads
      end subroutine alloc_subarray_4D
 
 
-end module fms_diag_averaging
+end module fms_diag_averaging_mod
 

--- a/fms_diag_axis.F90
+++ b/fms_diag_axis.F90
@@ -1,14 +1,17 @@
 module fms_diag_axis_mod
 
-use fms_diag_data_mod :: only, diag_error
-use fms2_io
+use fms_diag_data_mod,  only: diag_null, diag_error, fatal, note, warning
+use fms2_io_mod
 
+!!TODO:
 type domain1d
  integer :: filler
-end type domain2d
-type domain1d
+end type domain1d
+
+type domain2d
  integer :: filler
 end type domain2d
+
 type domainUG
  integer :: filler
 end type domainUG
@@ -29,7 +32,6 @@ type diag_axis_type
      class(*), allocatable, dimension (:) :: adata !< The axis data
      character (len=:), dimension(:), allocatable :: attributes !< The axis metadata
      logical, allocatable :: initialized
-
 end type diag_axis_type
 
 
@@ -48,11 +50,11 @@ public :: UP, DOWN, VOID_AXIS, HORIZONTAL
 contains
 
 subroutine fms_diag_axis_init (axis, aname, adata, units, cart, long_name, direction,&
-       & set_name, edges, Domain, Domain2, DomainU, aux, req, tile_count)
+       & set_name, edges, Domain, Domain2, DomainU, aux, req, tile_count, start, ending, attributes)
     type(diag_axis_type), intent(inout)      :: axis !< The axis object
     CHARACTER(len=*), INTENT(in)             :: aname !< The name of the axis
     class(*), target, INTENT(in), DIMENSION(:)    :: adata !< The axis data
-    class(*), pointer,          , DIMENSION(:)    :: dptr=> NULL() !< A pointer to the data
+    !class(*), pointer,          , DIMENSION(:)    :: dptr=> NULL() !< A pointer to the data
     CHARACTER(len=*), INTENT(in)             :: units !< The axis units
     CHARACTER(len=*), INTENT(in)             :: cart !< The cartesian name of the axis 
     CHARACTER(len=*), INTENT(in), OPTIONAL   :: long_name !< Axis long name
@@ -65,6 +67,9 @@ subroutine fms_diag_axis_init (axis, aname, adata, units, cart, long_name, direc
     CHARACTER(len=*), INTENT(in), OPTIONAL   :: aux !< ???
     CHARACTER(len=*), INTENT(in), OPTIONAL   :: req !< Is it required???
     INTEGER,          INTENT(in), OPTIONAL   :: tile_count !< The tile count
+    INTEGER,          INTENT(in), OPTIONAL   :: start !!TODO:
+    INTEGER,          INTENT(in), OPTIONAL   :: ending !!TODO:
+    CHARACTER(len=*), INTENT(in), OPTIONAL   :: attributes(:) !!TODO
 
     TYPE(domain1d) :: domain_x, domain_y
     INTEGER :: ierr, axlen
@@ -74,18 +79,22 @@ subroutine fms_diag_axis_init (axis, aname, adata, units, cart, long_name, direc
 
      integer :: ls       !< The local starting value
      integer :: le       !< the local ending value
-     integer :: i
-     if (len(cart) > 1) call diag_error("fms_diag_axis_init","CARTNAME for "//trim(aname)//&
-     " must only be one letter.  You have "//trim(cart),FATAL)
+
+     if (len(cart) > 1) then
+        call diag_error("fms_diag_axis_init","CARTNAME for "//trim(aname)// &
+            " must only be one letter.  You have " // trim(cart), FATAL)
+     end if
+
      if (cart .ne. "X" .or. cart .ne. "Y" .or. cart .ne. "Z" .or. &
-         cart .ne. "N" .or. cart .ne. "U" .or. cart .ne. "T") &
-          call diag_error("fms_diag_axis_init","CARTNAME for "//trim(aname)//" can only be X "//&
+         cart .ne. "N" .or. cart .ne. "U" .or. cart .ne. "T") then
+        call diag_error("fms_diag_axis_init","CARTNAME for "//trim(aname)//" can only be X "// &
           "Y Z U or N.  You have "//trim(cart), FATAL)
+          end if
      axis%aname = trim(aname)
      axis%cart = cart
      if (present(start)) then 
           axis%start = start
-     else 
+     else
           axis%start = 1
      endif
      if (present(ending)) then 
@@ -93,8 +102,8 @@ subroutine fms_diag_axis_init (axis, aname, adata, units, cart, long_name, direc
      else 
           axis%ending = 1
      endif
-     if (present(longname)) then 
-          axis%longname = trim(longname)
+     if (present(long_name)) then
+          axis%longname = trim(long_name)
      else
           axis%longname = trim(aname)
      endif
@@ -104,9 +113,9 @@ subroutine fms_diag_axis_init (axis, aname, adata, units, cart, long_name, direc
           axis%direction = HORIZONTAL
      endif
      if (present(attributes)) then 
-          alloacte(character(len=20) :: axis%attributes (size(attributes)))
+          allocate(character(len=20) :: axis%attributes (size(attributes)))
           do i = 1,size(attributes)
-               axis%attributes(i) =  attributes
+               axis%attributes(i) =  attributes(i)
           enddo
      endif
 

--- a/fms_diag_data.F90
+++ b/fms_diag_data.F90
@@ -51,12 +51,12 @@ type, bind(c) :: diag_fields_type
      character (c_char) :: module_location(20) !< The module
      character (c_char) :: key(8) !< Storage for the key in the yaml file
 end type diag_fields_type
+
 !> Placeholder for fms2_io file object type.
+!! TODO: Rename to fms_fname_type ?
 type fms_io_obj
-     character(len=100) :: fname
+    character(len=100) :: fname
 end type fms_io_obj
-
-
 
 
 integer :: fatal=-143, note=143, warning=143*2

--- a/fms_diag_send_data.F90
+++ b/fms_diag_send_data.F90
@@ -178,7 +178,7 @@ if(.not. diagobj%is_registeredB()) return
 
 !> Write the object if its static
 !> TODO: Only if its not yet writtennetcd
-if ( diagobj%is_static() ) then
+if ( .not. diagobj%is_static() ) then
     call write_static(diagobj, var, varname, time, is_in, js_in, ks_in, mask, &
                       rmask, ie_in, je_in, ke_in, weight, err_msg)
 !else write dynamic

--- a/fms_diag_write_data.F90
+++ b/fms_diag_write_data.F90
@@ -1,0 +1,88 @@
+module fms_diag_write_data_mod
+
+use fms_diag_data_mod, only: fms_io_obj !!TODO: Temporary
+use fms_diag_data_mod,  only: diag_null, diag_error, fatal, note, warning
+use fms_diag_object_mod, only: fms_diag_object, fms_diag_object_3d
+
+use fms_diag_axis_mod, only: diag_axis_type
+use fms_diag_averaging_mod, only: get_average, alloc_subarray
+!!use fms2_io_mod, only: open_file, close_file, write_data, FmsNetcdfFile_t
+use fms2_io_mod
+contains
+
+subroutine write_static (diag_obj, var, varname, time, is_in, js_in, ks_in, mask, &
+                                   rmask, ie_in, je_in, ke_in, weight, err_msg)
+    class (fms_diag_object),target, intent(inout), allocatable :: diag_obj !< The diag variable object
+    real(kind=8), dimension(:,:,:)   , intent(in) , target     :: var !< The variable !!TODO char(*) vs real
+    character(len=*), intent(in)                               :: varname  !!TODO: Is this neccesary
+
+    integer, optional            , intent(in)                  :: time !< A time place holder
+    integer, optional            , intent(in)                  :: is_in !< Start of the first dimension
+    integer, optional            , intent(in)                  :: js_in !< Start of the second dimension
+    integer, optional            , intent(in)                  :: ks_in !< Start of the third dimension
+    integer, optional            , intent(in)                  :: ie_in !< End of the first dimension
+    integer, optional            , intent(in)                  :: je_in !< End of the second dimension
+    integer, optional            , intent(in)                  :: ke_in !< End of the third dimension
+    logical, optional           , intent(in)                   :: mask !< A lask for point to ignore
+    real   , optional            , intent(in)                  :: rmask !< I DONT KNOW
+    real   , optional            , intent(in)                  :: weight !< Something for averaging?
+    CHARACTER(len=*)             , INTENT(out), OPTIONAL       :: err_msg
+    !! local vars
+    !!class(*), dimension(:,:), allocatable ::  avg   !!TODO: why class(*)
+    real(kind=8), dimension(:,:), allocatable ::  avg
+    logical              :: opened
+    integer              :: fn, an, i_v
+    type(diag_axis_type) :: an_axis !One axis
+    type (fms_io_obj)    :: a_file
+    type (FmsNetcdfFile_t) :: the_file
+    character(len=*), parameter :: metadata_name = "metadata" !! TODO: How do you get it
+
+    !! TODO: *** Why is diagobj%fms_fileobj an array ?
+    do fn = 1, size( diag_obj%fms_fileobj )
+        a_file =  diag_obj%fms_fileobj ( fn )
+        !! See netcdf_file_open_wrap(fileobj, path, mode,...from fms2_io
+        opened = open_file(the_file, a_file%fname, "append")
+        if (.not. opened) then
+            call diag_error("diag_mgr_wite_static", "The file " //the_file%path &
+            // " was not opened", FATAL)
+        end if
+    end do
+
+    !! Register the axss
+    do an  = 1,size(diag_obj%axis)
+        an_axis = diag_obj%axis( an )
+        !!...(use new dm2routine, see diyor)
+    end do
+
+    !! Write the metadata
+    call write_data(the_file, metadata_name, diag_obj%metadata)
+
+    !! Write the axes info
+    do an  = 1,size(diag_obj%axis)
+        an_axis = diag_obj%axis( an )
+        call write_data(the_file, an_axis%aname, an_axis%adata)
+    end do
+
+
+    !!TODO should not have to select over type use polymorphism?
+    select type (diag_obj)
+        type is (fms_diag_object_3d)   !! class is vs. type is
+            call alloc_subarray(var, avg);
+            !! TODO: include weight
+            call get_average(var, avg)
+            !call get_average(var, avg, is_in, ie_in, js_in, je_in, ks_in, ke_in)
+            !! TODO: Just wite the average or the data?
+            !! call write_data(the_file, diag_obj%vardata) !!TODO: Need variable name (at least)
+            call write_data(the_file, varname ,avg  ) !!TODO: Whats the variable name
+        class default
+            call diag_error("write_data", "type not supported yet", FATAL)
+    end select
+
+end subroutine  write_static
+
+end module fms_diag_write_data_mod
+
+!see diag_util.F90 subroutine write_static(file) L2689
+!see  SUBROUTINE diag_data_out(file, field, dat, time, final_call_in, static_write_in)
+! L2510 2565 2581
+!see fms2_io ...

--- a/test/diag_manager2/diag_manager_averaging_test.F90
+++ b/test/diag_manager2/diag_manager_averaging_test.F90
@@ -4,7 +4,7 @@
 !! Contains a program for testing module fms_diag_omp_aux
 program diag_manager_averaging_test
     use omp_lib
-    use fms_diag_averaging, only: get_average, alloc_subarray, num_offloading_threads
+    use fms_diag_averaging_mod, only: get_average, alloc_subarray, num_offloading_threads
     use fms_diag_averaging_dummy
     implicit none
 
@@ -226,7 +226,7 @@ end program diag_manager_averaging_test
     !Prints some info helpful in device offloading
     subroutine print_device_info()
         use omp_lib
-        use fms_diag_averaging, only: num_offloading_threads
+        use fms_diag_averaging_mod, only: num_offloading_threads
         implicit none
 
         integer :: num_threads, tid, num_gpu_threads,n_gpu_thread
@@ -273,4 +273,7 @@ end program diag_manager_averaging_test
 
 
     end subroutine print_device_info
+
+
+
 

--- a/test/diag_manager2/diag_manager_test2.F90
+++ b/test/diag_manager2/diag_manager_test2.F90
@@ -43,7 +43,7 @@ is=1 ; js=1 ; ks=1
      enddo
 
           if (id_tdata > diag_not_registered) then
-               call send_data(id_tdata, tdata(:,:,:,t), t, is, js, ks)
+               call send_data(id_tdata, tdata(:,:,:,t),"tdata",  t, is, js, ks)
           endif
           if (id_2d > diag_not_registered) then
            write (6,*) "Call send data"


### PR DESCRIPTION
This is an inital send_data for 3D static data using fms2_io.
In class fms_diag_obj:
a)  The new file fms_diag_write_data.F90 has subroutine write_static which uses  fms2_io to write. 
 fms_send_data3d was modified to call this write_static subroutine. (The contents of the write_static 
subroutine will be moved be moved to fms_send_data3d by the next merge).
b) and some new inquiry functions were added to fms_diag_obj.
